### PR TITLE
Adds open timeout option to request

### DIFF
--- a/lib/wrest/native/connection_factory.rb
+++ b/lib/wrest/native/connection_factory.rb
@@ -9,10 +9,12 @@
 
 module Wrest::Native
   module ConnectionFactory
-    def create_connection(options = {:timeout => 60, :verify_mode => OpenSSL::SSL::VERIFY_NONE})
+    def create_connection(options = {:timeout => 60, :open_timeout => 60, :verify_mode => OpenSSL::SSL::VERIFY_NONE})
       options[:timeout] ||= 60
+      options[:open_timeout] ||= 60
       connection = Net::HTTP.new(self.host, self.port)
       connection.read_timeout = options[:timeout]
+      connection.open_timeout = options[:open_timeout]
       if self.https?
         connection.use_ssl     = true
         connection.verify_mode = options[:verify_mode] ? options[:verify_mode] : OpenSSL::SSL::VERIFY_PEER 

--- a/lib/wrest/native/request.rb
+++ b/lib/wrest/native/request.rb
@@ -53,6 +53,7 @@ module Wrest::Native
       @follow_redirects_count = (@options[:follow_redirects_count] ||= 0)
       @follow_redirects_limit = (@options[:follow_redirects_limit] ||= 5)
       @timeout = @options[:timeout]
+      @open_timeout = @options[:open_timeout]
       @connection = @options[:connection]
       @http_request = self.build_request(http_request_klass, @uri, @parameters, @headers)
       @cache_store = @options[:cache_store]
@@ -86,7 +87,7 @@ module Wrest::Native
     # This is followed by the response code, the payload size and the time taken.
     def invoke
       response = nil
-      @connection ||= @uri.create_connection(:timeout => timeout, :verify_mode => verify_mode, :ca_path => ca_path)
+      @connection ||= @uri.create_connection(:timeout => timeout, :open_timeout => @open_timeout, :verify_mode => verify_mode, :ca_path => ca_path)
       @connection.set_debug_output @detailed_http_logging
       http_request.basic_auth username, password unless username.nil? || password.nil?
 

--- a/spec/wrest/native/redirection_spec.rb
+++ b/spec/wrest/native/redirection_spec.rb
@@ -36,6 +36,7 @@ describe Wrest::Native::Redirection do
 
     http_connection = double(Net::HTTP)
     allow(http_connection).to receive(:read_timeout=)
+    allow(http_connection).to receive(:open_timeout=)
     allow(http_connection).to receive(:set_debug_output)
     http_connection.should_receive(:request).exactly(5).times.and_return(response)
 

--- a/spec/wrest/native/request_spec.rb
+++ b/spec/wrest/native/request_spec.rb
@@ -175,10 +175,16 @@ describe Wrest::Native::Request do
     end
 
 
-    it "should raise a Wrest exception on timeout" do
+    it "should raise a Wrest exception on read timeout" do
       lambda{
         Wrest::Native::Request.new('http://localhost:3000/two_seconds'.to_uri, Net::HTTP::Get, {}, '', {}, :timeout => 1).invoke
         }.should raise_error(Wrest::Exceptions::Timeout)
+    end
+
+    it "should raise a Wrest exception on open timeout" do
+      lambda{
+        Wrest::Native::Request.new('http://www.example.com:81/'.to_uri, Net::HTTP::Get, {}, '', {}, :open_timeout => 1).invoke
+      }.should raise_error(Wrest::Exceptions::Timeout)
     end
   end
 end

--- a/spec/wrest/native/session_spec.rb
+++ b/spec/wrest/native/session_spec.rb
@@ -21,6 +21,7 @@ module Wrest
       http = double(Net::HTTP)
       Net::HTTP.should_receive(:new).with('localhost', 3000).and_return(http)
       http.should_receive(:read_timeout=).with(60)
+      http.should_receive(:open_timeout=).with(60)
       http.should_receive(:set_debug_output).at_least(1).times
 
       request_one = Net::HTTP::Get.new('/glassware?owner=Kai&type=bottle', {H::Connection=>T::KeepAlive})
@@ -50,6 +51,7 @@ module Wrest
       http = double(Net::HTTP)
       Net::HTTP.should_receive(:new).with('localhost', 3000).and_return(http)
       http.should_receive(:read_timeout=).with(60)
+      http.should_receive(:open_timeout=).with(60)
 
       request_one = Net::HTTP::Get.new('/glassware?owner=Kai&type=bottle', {H::Connection=>T::KeepAlive})
       request_two = Net::HTTP::Get.new('/bottles.xml', {H::Connection=>T::KeepAlive})

--- a/spec/wrest/uri_spec.rb
+++ b/spec/wrest/uri_spec.rb
@@ -185,6 +185,7 @@ module Wrest
         http = double(Net::HTTP)
         Net::HTTP.should_receive(:new).with('localhost', 3000).and_return(http)
         http.should_receive(:read_timeout=).with(60)
+        http.should_receive(:open_timeout=).with(60)
         http.should_receive(:set_debug_output).with(nil)
         http
       end
@@ -449,6 +450,7 @@ module Wrest
         http = double(Net::HTTP)
         Net::HTTP.should_receive(:new).with('localhost', 3000).at_least(1).times.and_return(http)
         http.should_receive(:read_timeout=).at_least(1).times.with(60)
+        http.should_receive(:open_timeout=).at_least(1).times.with(60)
         http.should_receive(:set_debug_output).at_least(1).times
 
         request_get = Net::HTTP::Get.new('/glassware?owner=Kai&type=bottle', {'page' => '2', 'per_page' => '5'})


### PR DESCRIPTION
Wrest exposes only read_timeout. In cases where wrest is not able to open a connection, it takes 60 seconds to get timed out. This can be configured by setting an open timeout of Net::Http - https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html.